### PR TITLE
add swiglu-search.py

### DIFF
--- a/swiglu-search.py
+++ b/swiglu-search.py
@@ -60,6 +60,7 @@ def benchmark_bmm(b, m, n, k, num_iterations=100, num_matmuls=1):
     return flops_per_sec
 
 
+print(f"Wanted the closest to {d_ff_base} d_ff value that leads to the highest TFLOPS\n")
 print(f"Searching {int(distance/2)} steps in the range of {d_ff_base-distance} .. {d_ff_base+distance}")
 results = {}
 for d in trange(-distance, distance, 4):
@@ -70,7 +71,6 @@ for d in trange(-distance, distance, 4):
     results[d_ff] = benchmark_bmm(batch_size, m=d_hidden, n=d_ff, k=d_hidden, num_iterations=num_iterations, num_matmuls=1)
 
 starting_tflops_per_sec = benchmark_bmm(batch_size, m=d_hidden, n=d_ff_base, k=d_hidden, num_iterations=num_iterations, num_matmuls=1)
-print(f"Wanted the closest to {d_ff_base} d_ff value that leads to the highest TFLOPS\n")
 print("Results: baseline, followed by near-by best performing d_ff results:\n")
 print("size  tflops mlp_params")
 print(f"{d_ff_base} {starting_tflops_per_sec:7.2f} {3*d_ff_base*d_hidden}")

--- a/swiglu-search.py
+++ b/swiglu-search.py
@@ -1,0 +1,82 @@
+# This script will help you find the intermediate value of the hidden layer of the MLP when SwiGLU
+# is used.
+#
+# It performs a brute force search for the best number closest to 8/3*h that would give the highest
+# TFLOPS for a matmal of [b*s, h]×[h, 8/3*h]
+#
+# It's searching only one matmul instead of the actual 3, since the performance is the same
+#
+# In the situation where tensor parallelism is used (Megatron) with tp>1 it'd be even faster to
+# search for m1 = m/tp - so 1/8th with tp=8
+#
+# To adapt for your situation please modify the search parameters below
+
+import time
+import torch
+import numpy as np
+import tqdm
+from tqdm import trange
+
+### Modify the Search Parameters Begin ###
+
+# this is the hidden_size of the model
+d_hidden = 4096
+
+# Now either let the 8/3 ratio give be the starting dimension size or choose you own - the 8/3 is
+# only a suggestion to compensate for the 3rd additional matrix
+d_ff_base = int(8/3*d_hidden)
+#d_ff_base = 11008
+
+# batch size - make it larger for small matrices
+batch_size = 2**2
+
+# add more profiler iterations for small matrices
+num_iterations = 100
+
+# searching range: (d_ff_base-distance) < d_ff_base < d_ff_base+distance
+distance = 100
+
+### Modify the Search Parameters End ###
+
+def benchmark_bmm(b, m, n, k, num_iterations=100, num_matmuls=1):
+    A = torch.randn((b, m, n)).half().to("cuda:0")
+    B = torch.randn((b, n, k)).half().to("cuda:0")
+    C = torch.empty((b, m, k)).half().to("cuda:0")
+    num_warmup_iterations = 50
+
+    start_event = torch.cuda.Event(enable_timing=True)
+    end_event = torch.cuda.Event(enable_timing=True)
+
+    for i in range(num_warmup_iterations + num_iterations):
+        if i == num_warmup_iterations:
+            start_event.record()
+        with torch.no_grad():
+            for i in range(num_matmuls):
+                torch.bmm(A, B, out=C)
+    end_event.record()
+    torch.cuda.synchronize()
+    elapsed_time = start_event.elapsed_time(end_event) / (1000 * num_iterations)
+    flops_per_sec = (2 * b * m * n * k * num_matmuls) / (elapsed_time * 10**12)
+    #print(f"Elapsed time for {num_matmuls} times {b}x{m}x{n}x{k} : {elapsed_time:.3f}")
+    #print(f"Throughput (in TFLOP/s) for {b}x{m}x{n}x{k}: {flops_per_sec:.3f}")
+    #print("-" * 80)
+    return flops_per_sec
+
+
+print(f"Searching {int(distance/2)} steps in the range of {d_ff_base-distance} .. {d_ff_base+distance}")
+results = {}
+for d in trange(-distance, distance, 4):
+    d_ff = d_ff_base + d
+    # find closest div 4 number, pointless to search odd numbers
+    d_ff -= d_ff % 4
+    #print(d_ff)
+    results[d_ff] = benchmark_bmm(batch_size, m=d_hidden, n=d_ff, k=d_hidden, num_iterations=num_iterations, num_matmuls=1)
+
+starting_tflops_per_sec = benchmark_bmm(batch_size, m=d_hidden, n=d_ff_base, k=d_hidden, num_iterations=num_iterations, num_matmuls=1)
+print(f"Wanted the closest to {d_ff_base} d_ff value that leads to the highest TFLOPS")
+print(f"The starting value gives the following TFLOPS:")
+print(f"{d_ff_base} {starting_tflops_per_sec:.2f}")
+print("Near-by best performing d_ff results (best first)")
+cut_off = 5 # how many results do you want to see
+for k in list(reversed(sorted(results, key=lambda x: results[x])))[:cut_off]:
+    print(f"{k} {results[k]:.2f}")

--- a/swiglu-search.py
+++ b/swiglu-search.py
@@ -19,7 +19,7 @@ from tqdm import trange
 # this is the hidden_size of the model
 d_hidden = 4096
 
-# Now either let the 8/3 ratio give be the starting dimension size or choose you own - the 8/3 is
+# Now either let the 8/3 ratio give the starting dimension size or choose you own - the 8/3 is
 # only a suggestion to compensate for the 3rd additional matrix
 d_ff_base = int(8/3*d_hidden)
 #d_ff_base = 11008

--- a/swiglu-search.py
+++ b/swiglu-search.py
@@ -11,10 +11,7 @@
 #
 # To adapt for your situation please modify the search parameters below
 
-import time
 import torch
-import numpy as np
-import tqdm
 from tqdm import trange
 
 ### Modify the Search Parameters Begin ###

--- a/swiglu-search.py
+++ b/swiglu-search.py
@@ -30,7 +30,7 @@ batch_size = 2**2
 # add more profiler iterations for small matrices
 num_iterations = 100
 
-# searching range: (d_ff_base-distance) < d_ff_base < d_ff_base+distance
+# searching range: d_ff_base-distance < d_ff_base < d_ff_base+distance
 distance = 100
 
 ### Modify the Search Parameters End ###
@@ -70,10 +70,10 @@ for d in trange(-distance, distance, 4):
     results[d_ff] = benchmark_bmm(batch_size, m=d_hidden, n=d_ff, k=d_hidden, num_iterations=num_iterations, num_matmuls=1)
 
 starting_tflops_per_sec = benchmark_bmm(batch_size, m=d_hidden, n=d_ff_base, k=d_hidden, num_iterations=num_iterations, num_matmuls=1)
-print(f"Wanted the closest to {d_ff_base} d_ff value that leads to the highest TFLOPS")
-print(f"The starting value gives the following TFLOPS:")
-print(f"{d_ff_base} {starting_tflops_per_sec:.2f}")
-print("Near-by best performing d_ff results (best first)")
-cut_off = 5 # how many results do you want to see
-for k in list(reversed(sorted(results, key=lambda x: results[x])))[:cut_off]:
-    print(f"{k} {results[k]:.2f}")
+print(f"Wanted the closest to {d_ff_base} d_ff value that leads to the highest TFLOPS\n")
+print("Results: baseline, followed by near-by best performing d_ff results:\n")
+print("size  tflops mlp_params")
+print(f"{d_ff_base} {starting_tflops_per_sec:7.2f} {3*d_ff_base*d_hidden}")
+cut_off = 5  # how many results do you want to see
+for d_ff in list(reversed(sorted(results, key=lambda x: results[x])))[:cut_off]:
+    print(f"{d_ff} {results[d_ff]:7.2f} {3*d_ff*d_hidden}")

--- a/swiglu-search.py
+++ b/swiglu-search.py
@@ -72,7 +72,7 @@ for d in trange(-distance, distance, 4):
 
 starting_tflops_per_sec = benchmark_bmm(batch_size, m=d_hidden, n=d_ff_base, k=d_hidden, num_iterations=num_iterations, num_matmuls=1)
 print("Results: baseline, followed by near-by best performing d_ff results:\n")
-print("size  tflops mlp_params")
+print(" d_ff  tflops mlp_params")
 print(f"{d_ff_base} {starting_tflops_per_sec:7.2f} {3*d_ff_base*d_hidden}")
 cut_off = 5  # how many results do you want to see
 for d_ff in list(reversed(sorted(results, key=lambda x: results[x])))[:cut_off]:


### PR DESCRIPTION
this is the brute search helper util to find the best intermediate value when SwiGLU is used.

Output
```
$ python swiglu-search.py
Wanted the closest to 10922 d_ff value that leads to the highest TFLOPS
Searching 50 steps in the range of 10822 .. 11022
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████| 50/50 [03:23<00:00,  4.06s/it]

Results: baseline, followed by near-by best performing d_ff results:

 d_ff  tflops mlp_params
10922  165.84 134209536
10912  244.49 134086656
10944  244.36 134479872
10848  244.32 133300224
10880  244.28 133693440
10976  244.24 134873088
```